### PR TITLE
Avoid specifying an endpoint verbosely in demo app

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ The states have effects across device reboots, app updates, so you can simply ca
 The API endpoint (default: https://in.treasuredata.com) can be modified using  `TreasureData.initializeApiEndpoint`. For example:
 
 ```
-    TreasureData.initializeApiEndpoint("https://in.treasuredata.com");
+    TreasureData.initializeApiEndpoint("https://specifying-another-endpoint.com");
     td = new TreasureData(this, "your_api_key");
 ```
 

--- a/example/td-android-sdk-demo/src/com/treasuredata/android/demo/DemoApp.java
+++ b/example/td-android-sdk-demo/src/com/treasuredata/android/demo/DemoApp.java
@@ -12,7 +12,7 @@ public class DemoApp extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
-        TreasureData.initializeApiEndpoint("https://in.treasuredata.com/");
+        // TreasureData.initializeApiEndpoint("https://specify-other-endpoint-if-needed.com");
         TreasureData.enableLogging();
         TreasureData.initializeEncryptionKey("hello world");
         TreasureData.setSessionTimeoutMilli(30 * 1000);


### PR DESCRIPTION
Original code specified an endpoint that's same as default endpoint. Developers don't need to specify it in their app.

Also, the endpoint has a tail slash. It can introduce sequential slashes and it could cause troubles in the future.