### PR TITLE
Implement Auto tracking Advertising Id feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ UUID will be added to each event record automatically if you call `enableAutoApp
 It outputs the value as a column name `record_uuid` by default.
 
 ### Adding Advertising Id to each event record automatically
-Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`. You must install Google Play Service Ads (Gradle com.google.android.gms:play-services-ads) as an dependency for this feature to work. User must also not turn on Limit Ad Tracking feature in their device, otherwise Treasure Data will not attach advertising id to the record.
+Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`. You must install Google Play Service Ads (Gradle `com.google.android.gms:play-services-ads`) as a dependency for this feature to work. User must also not turn on Limit Ad Tracking feature in their device, otherwise, Treasure Data will not attach Advertising Id to the record.
 
 ```
 td.enableAutoAppendAdvertisingIdentifier();

--- a/README.md
+++ b/README.md
@@ -366,6 +366,19 @@ UUID will be added to each event record automatically if you call `enableAutoApp
 
 It outputs the value as a column name `record_uuid` by default.
 
+### Adding Advertising Id to each event record automatically
+Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`. You must install Google Play Service Ads (Gradle com.google.android.gms:play-services-ads) as an dependency for this feature to work. User must also not turn on Limit Ad Tracking feature in their device, otherwise Treasure Data will not attach advertising id to the record.
+
+```
+td.enableAutoAppendAdvertisingIdentifier();
+// If you want to customize the column name, pass it to the API
+// td.enableAutoAppendAdvertisingIdentifier("my_advertising_id_column");
+:
+td.addEvent(...);
+```
+
+It outputs the value as a column name `td_maid` by default.
+
 
 ### Adding device model information to each event automatically
 

--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ It outputs the value as a column name `record_uuid` by default.
 
 ### Adding Advertising Id to each event record automatically
 Advertising Id will be added to each event record automatically if you call `enableAutoAppendAdvertisingIdentifier`. You must install Google Play Service Ads (Gradle `com.google.android.gms:play-services-ads`) as a dependency for this feature to work. User must also not turn on Limit Ad Tracking feature in their device, otherwise, Treasure Data will not attach Advertising Id to the record.
+Due to asynchronous nature of getting Advertising Id, after enableAutoAppendAdvertisingIdentifier method called, it may take some time for Advertising Id to be available to be added to the record. However, Treasure Data does cache the Advertising Id in order to add to the next event without having to wait for the fetch Advertising Id task to complete.
 
 ```
 td.enableAutoAppendAdvertisingIdentifier();

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 
     compileOnly 'com.google.android:android:4.1.1.4'
 
+    testCompile 'com.google.android.gms:play-services-ads:17.1.1'
     testCompile 'junit:junit:4.11'
     testCompile 'org.mockito:mockito-core:1.8.5'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.6.0'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -35,11 +35,16 @@ repositories {
     jcenter()
     google()
     mavenCentral()
-    mavenLocal()  // FIXME: remove
+//    mavenLocal()  // FIXME: remove
 }
 
 dependencies {
     implementation rootProject
+    implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:customtabs:28.0.0'
+    implementation 'com.android.support:animated-vector-drawable:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
     implementation 'com.google.android.gms:play-services-ads:17.1.1'
 
     testImplementation 'junit:junit:4.12'

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -40,7 +40,9 @@ repositories {
 
 dependencies {
     implementation rootProject
+    implementation 'com.google.android.gms:play-services-ads:17.1.1'
 
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
+
 }

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -25,6 +25,10 @@
                 <action android:name="com.android.vending.INSTALL_REFERRER" />
             </intent-filter>
         </receiver>
+
+        <meta-data
+            android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+            android:value="true" />
     </application>
 
 </manifest>

--- a/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
+++ b/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
@@ -23,6 +23,7 @@ public class DemoApp extends Application {
         TreasureData.sharedInstance().enableAutoAppendLocaleInformation();
         TreasureData.sharedInstance().enableServerSideUploadTimestamp("server_upload_time");
         TreasureData.sharedInstance().enableAutoAppendRecordUUID();
+        TreasureData.sharedInstance().enableAutoAppendAdvertisingIdentifier();
         TreasureData.sharedInstance().setDefaultDatabase("test_db");
         TreasureData.sharedInstance().setDefaultTable("test_tbl");
     }

--- a/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
+++ b/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
@@ -23,7 +23,7 @@ public class DemoApp extends Application {
         TreasureData.sharedInstance().enableAutoAppendLocaleInformation();
         TreasureData.sharedInstance().enableServerSideUploadTimestamp("server_upload_time");
         TreasureData.sharedInstance().enableAutoAppendRecordUUID();
-        TreasureData.sharedInstance().enableAutoAppendAdvertisingIdentifier();
+        TreasureData.sharedInstance().enableAutoAppendAdvertisingIdentifier("custom_td_maid");
         TreasureData.sharedInstance().setDefaultDatabase("test_db");
         TreasureData.sharedInstance().setDefaultTable("test_tbl");
     }

--- a/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
+++ b/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
@@ -5,7 +5,7 @@ import android.content.Context;
 
 import org.komamitsu.android.util.Log;
 
-class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, Void> {
+class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, String> {
     private static final String TAG = GetAdvertisingIdAsyncTask.class.getSimpleName();
     private final GetAdvertisingIdAsyncTaskCallback callback;
 
@@ -14,7 +14,7 @@ class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, Void> {
     }
 
     @Override
-    protected Void doInBackground(Context... params) {
+    protected String doInBackground(Context... params) {
         Context context = params[0];
         try {
             Object advertisingInfo = Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient")
@@ -27,15 +27,19 @@ class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, Void> {
                 String advertisingId = (String) advertisingInfo.getClass()
                         .getMethod("getId")
                         .invoke(advertisingInfo);
-                callback.onGetAdvertisingIdAsyncTaskCompleted(advertisingId);
+                return advertisingId;
             } else {
-                callback.onGetAdvertisingIdAsyncTaskCompleted(null);
+                return null;
             }
         } catch (Exception e) {
             // Customer does not include google services ad library, indicate not wanting to track Advertising Id
             Log.w(TAG, "Exception getting advertising id: " + e.getMessage(), e);
-            callback.onGetAdvertisingIdAsyncTaskCompleted(null);
+            return null;
         }
-        return null;
+    }
+
+    @Override
+    protected void onPostExecute(String advertisingId) {
+        callback.onGetAdvertisingIdAsyncTaskCompleted(advertisingId);
     }
 }

--- a/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
+++ b/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
@@ -32,7 +32,7 @@ class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, String> {
         } catch (ClassNotFoundException e) {
             // Customer does not include google services ad library, indicate not wanting to track Advertising Id
             Log.w(TAG, "Exception getting advertising id: " + e.getMessage(), e);
-            Log.w(TAG, "You are attempting to enable auto append Advertising Identifer but AdvertisingIdClient class is not detected. To use this feature, you must use Google Mobile Ads library");
+            Log.w(TAG, "You are attempting to enable auto append Advertising Identifier but AdvertisingIdClient class is not detected. To use this feature, you must use Google Mobile Ads library");
         }  catch (Exception e) {
             throw e;
         }

--- a/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
+++ b/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTask.java
@@ -1,0 +1,41 @@
+package com.treasuredata.android;
+
+import android.os.AsyncTask;
+import android.content.Context;
+
+import org.komamitsu.android.util.Log;
+
+class GetAdvertisingIdAsyncTask extends AsyncTask<Context, Void, Void> {
+    private static final String TAG = GetAdvertisingIdAsyncTask.class.getSimpleName();
+    private final GetAdvertisingIdAsyncTaskCallback callback;
+
+    GetAdvertisingIdAsyncTask(GetAdvertisingIdAsyncTaskCallback callback) {
+        this.callback = callback;
+    }
+
+    @Override
+    protected Void doInBackground(Context... params) {
+        Context context = params[0];
+        try {
+            Object advertisingInfo = Class.forName("com.google.android.gms.ads.identifier.AdvertisingIdClient")
+                    .getMethod("getAdvertisingIdInfo", Context.class)
+                    .invoke(null, context);
+            Boolean isLimitAdTrackingEnabled = (Boolean) advertisingInfo.getClass()
+                    .getMethod("isLimitAdTrackingEnabled")
+                    .invoke(advertisingInfo);
+            if (!isLimitAdTrackingEnabled) {
+                String advertisingId = (String) advertisingInfo.getClass()
+                        .getMethod("getId")
+                        .invoke(advertisingInfo);
+                callback.onGetAdvertisingIdAsyncTaskCompleted(advertisingId);
+            } else {
+                callback.onGetAdvertisingIdAsyncTaskCompleted(null);
+            }
+        } catch (Exception e) {
+            // Customer does not include google services ad library, indicate not wanting to track Advertising Id
+            Log.w(TAG, "Exception getting advertising id: " + e.getMessage(), e);
+            callback.onGetAdvertisingIdAsyncTaskCompleted(null);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTaskCallback.java
+++ b/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTaskCallback.java
@@ -1,0 +1,5 @@
+package com.treasuredata.android;
+
+public interface GetAdvertisingIdAsyncTaskCallback {
+    void onGetAdvertisingIdAsyncTaskCompleted(String advertisingId);
+}

--- a/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTaskCallback.java
+++ b/src/main/java/com/treasuredata/android/GetAdvertisingIdAsyncTaskCallback.java
@@ -1,5 +1,5 @@
 package com.treasuredata.android;
 
-public interface GetAdvertisingIdAsyncTaskCallback {
+interface GetAdvertisingIdAsyncTaskCallback {
     void onGetAdvertisingIdAsyncTaskCompleted(String advertisingId);
 }

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -208,7 +208,7 @@ public class TreasureData implements CDPClient {
         }
     }
 
-    public String getAdvertisingId() {
+    String getAdvertisingId() {
         return advertisingId;
     }
 

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -888,8 +888,7 @@ public class TreasureData implements CDPClient {
     }
 
     public void enableAutoAppendAdvertisingIdentifier() {
-        this.autoAppendAdvertisingIdColumn = EVENT_KEY_ADVERTISING_IDENTIFIER;
-        updateAdvertisingId();
+        enableAutoAppendAdvertisingIdentifier(EVENT_KEY_ADVERTISING_IDENTIFIER);
     }
 
     public void enableAutoAppendAdvertisingIdentifier(String columnName) {

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -208,6 +208,10 @@ public class TreasureData implements CDPClient {
         }
     }
 
+    public String getAdvertisingId() {
+        return advertisingId;
+    }
+
     public boolean isFirstRun(Context context) {
         SharedPreferences sharedPreferences = getSharedPreference(context);
         synchronized (this) {
@@ -666,8 +670,9 @@ public class TreasureData implements CDPClient {
 
     public void appendAdvertisingIdentifier(Map<String, Object> record) {
         updateAdvertisingId();
-        if (advertisingId != null) {
-            record.put(autoAppendAdvertisingIdColumn, advertisingId);
+
+        if (getAdvertisingId() != null) {
+            record.put(autoAppendAdvertisingIdColumn, getAdvertisingId());
         }
     }
 
@@ -892,7 +897,7 @@ public class TreasureData implements CDPClient {
     }
 
     public void enableAutoAppendAdvertisingIdentifier(String columnName) {
-        if (columnName != null) {
+        if (columnName == null) {
             Log.w(TAG, "columnName must not be null");
             return;
         }

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -104,7 +104,6 @@ public class TreasureData implements CDPClient {
     private volatile boolean customEventEnabled = true;
     private volatile boolean appLifecycleEventEnabled;
     private volatile boolean inAppPurchaseEventEnabled;
-    private volatile boolean autoAppendAdvertisingIdentifier;
     private static volatile long sessionTimeoutMilli = Session.DEFAULT_SESSION_PENDING_MILLIS;
     private final String appVersion;
     private final int appVersionNumber;
@@ -112,6 +111,7 @@ public class TreasureData implements CDPClient {
     private volatile String serverSideUploadTimestampColumn;
     private Session session = new Session();
     private volatile String autoAppendRecordUUIDColumn;
+    private volatile String autoAppendAdvertisingIdColumn;
     private volatile String advertisingId;
 
     private final AtomicBoolean isInAppPurchaseEventTracking = new AtomicBoolean(false);
@@ -530,7 +530,7 @@ public class TreasureData implements CDPClient {
             appendRecordUUID(record);
         }
 
-        if (autoAppendAdvertisingIdentifier) {
+        if (autoAppendAdvertisingIdColumn != null) {
             appendAdvertisingIdentifier(record);
         }
 
@@ -667,7 +667,7 @@ public class TreasureData implements CDPClient {
     public void appendAdvertisingIdentifier(Map<String, Object> record) {
         updateAdvertisingId();
         if (advertisingId != null) {
-            record.put(EVENT_KEY_ADVERTISING_IDENTIFIER, advertisingId);
+            record.put(autoAppendAdvertisingIdColumn, advertisingId);
         }
     }
 
@@ -888,7 +888,16 @@ public class TreasureData implements CDPClient {
     }
 
     public void enableAutoAppendAdvertisingIdentifier() {
-        this.autoAppendAdvertisingIdentifier = true;
+        this.autoAppendAdvertisingIdColumn = EVENT_KEY_ADVERTISING_IDENTIFIER;
+        updateAdvertisingId();
+    }
+
+    public void enableAutoAppendAdvertisingIdentifier(String columnName) {
+        if (columnName != null) {
+            Log.w(TAG, "columnName must not be null");
+            return;
+        }
+        this.autoAppendAdvertisingIdColumn = columnName;
         updateAdvertisingId();
     }
 
@@ -906,7 +915,7 @@ public class TreasureData implements CDPClient {
     }
 
     public void disableAutoAppendAdvertisingIdentifier() {
-        this.autoAppendAdvertisingIdentifier = false;
+        this.autoAppendAdvertisingIdColumn = null;
         advertisingId = null;
     }
 

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -669,7 +669,7 @@ public class TreasureData implements CDPClient {
         record.put(autoAppendRecordUUIDColumn, UUID.randomUUID().toString());
     }
 
-    public void appendAdvertisingIdentifier(Map<String, Object> record) {
+    private void appendAdvertisingIdentifier(Map<String, Object> record) {
         updateAdvertisingId();
 
         if (getAdvertisingId() != null) {

--- a/src/test/java/com/treasuredata/android/TreasureDataTest.java
+++ b/src/test/java/com/treasuredata/android/TreasureDataTest.java
@@ -357,41 +357,6 @@ public class TreasureDataTest extends TestCase {
         assertTrue(client.addedEvent.get(0).event.containsValue("val"));
     }
 
-    public void testEnableAutoAppendAdvertisingId() throws IOException {
-        when(td.getAdvertisingId()).thenReturn("1234-5678-1234-5678");
-
-        td.enableAutoAppendAdvertisingIdentifier();
-
-        Map<String, Object>records = new HashMap<String, Object>();
-        records.put("key", "val");
-        td.addEvent("db_", "tbl", records);
-        td.uploadEvents();
-        assertEquals(1, client.addedEvent.size());
-        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
-        assertEquals(2, client.addedEvent.get(0).event.size());
-        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
-        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
-        assertTrue(client.addedEvent.get(0).event.containsKey("td_maid"));
-        assertTrue(client.addedEvent.get(0).event.containsValue("1234-5678-1234-5678"));
-    }
-
-    public void testDisableAutoAppendAdvertisingId() throws IOException {
-        when(td.getAdvertisingId()).thenReturn("1234-5678-1234-5678");
-
-        td.enableAutoAppendAdvertisingIdentifier();
-        td.disableAutoAppendAdvertisingIdentifier();
-
-        Map<String, Object>records = new HashMap<String, Object>();
-        records.put("key", "val");
-        td.addEvent("db_", "tbl", records);
-        td.uploadEvents();
-        assertEquals(1, client.addedEvent.size());
-        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
-        assertEquals(1, client.addedEvent.get(0).event.size());
-        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
-        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
-    }
-
     public void testAddEventWithUniqueRecordIdWithCustomizedColumnName() throws IOException {
         td.enableAutoAppendRecordUUID("my_record_id");
         Map<String, Object> records = new HashMap<String, Object>();

--- a/src/test/java/com/treasuredata/android/TreasureDataTest.java
+++ b/src/test/java/com/treasuredata/android/TreasureDataTest.java
@@ -2,6 +2,7 @@ package com.treasuredata.android;
 
 import android.app.Application;
 import android.content.Context;
+
 import io.keen.client.java.KeenCallback;
 import io.keen.client.java.KeenClient;
 import io.keen.client.java.KeenProject;
@@ -346,6 +347,41 @@ public class TreasureDataTest extends TestCase {
         td.enableAutoAppendRecordUUID();
         td.disableAutoAppendRecordUUID();
         Map<String, Object> records = new HashMap<String, Object>();
+        records.put("key", "val");
+        td.addEvent("db_", "tbl", records);
+        td.uploadEvents();
+        assertEquals(1, client.addedEvent.size());
+        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
+        assertEquals(1, client.addedEvent.get(0).event.size());
+        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
+        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
+    }
+
+    public void testEnableAutoAppendAdvertisingId() throws IOException {
+        when(td.getAdvertisingId()).thenReturn("1234-5678-1234-5678");
+
+        td.enableAutoAppendAdvertisingIdentifier();
+
+        Map<String, Object>records = new HashMap<String, Object>();
+        records.put("key", "val");
+        td.addEvent("db_", "tbl", records);
+        td.uploadEvents();
+        assertEquals(1, client.addedEvent.size());
+        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
+        assertEquals(2, client.addedEvent.get(0).event.size());
+        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
+        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
+        assertTrue(client.addedEvent.get(0).event.containsKey("td_maid"));
+        assertTrue(client.addedEvent.get(0).event.containsValue("1234-5678-1234-5678"));
+    }
+
+    public void testDisableAutoAppendAdvertisingId() throws IOException {
+        when(td.getAdvertisingId()).thenReturn("1234-5678-1234-5678");
+
+        td.enableAutoAppendAdvertisingIdentifier();
+        td.disableAutoAppendAdvertisingIdentifier();
+
+        Map<String, Object>records = new HashMap<String, Object>();
         records.put("key", "val");
         td.addEvent("db_", "tbl", records);
         td.uploadEvents();

--- a/test-host/build.gradle
+++ b/test-host/build.gradle
@@ -38,6 +38,11 @@ dependencies {
     implementation rootProject
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
+    implementation 'com.android.support:customtabs:28.0.0'
+    implementation 'com.android.support:animated-vector-drawable:28.0.0'
+    implementation 'com.android.support:support-media-compat:28.0.0'
+    implementation 'com.android.support:support-v4:28.0.0'
+    implementation 'com.google.android.gms:play-services-ads:17.1.1'
 
     testImplementation 'junit:junit:4.12'
 

--- a/test-host/src/androidTest/java/com/treasuredata/android/GetAdvertisingAsyncTaskTest.java
+++ b/test-host/src/androidTest/java/com/treasuredata/android/GetAdvertisingAsyncTaskTest.java
@@ -1,0 +1,30 @@
+package com.treasuredata.android;
+
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.concurrent.CountDownLatch;
+
+@RunWith(AndroidJUnit4.class)
+public class GetAdvertisingAsyncTaskTest extends TestCase {
+    @Test
+    public void getAdvertisingId() {
+        final CountDownLatch latch = new CountDownLatch(1);
+        Context context = InstrumentationRegistry.getTargetContext();
+        final GetAdvertisingIdAsyncTask task =
+                new GetAdvertisingIdAsyncTask(new GetAdvertisingIdAsyncTaskCallback() {
+                    @Override
+                    public void onGetAdvertisingIdAsyncTaskCompleted(String advertisingId) {
+                        latch.countDown();
+                        assertNotNull(advertisingId);
+                    }
+                });
+        task.execute(context);
+    }
+}

--- a/test-host/src/androidTest/java/com/treasuredata/android/TreasureDataInstrumentTest.java
+++ b/test-host/src/androidTest/java/com/treasuredata/android/TreasureDataInstrumentTest.java
@@ -1,0 +1,135 @@
+package com.treasuredata.android;
+
+import android.app.Application;
+import android.content.Context;
+import android.support.test.InstrumentationRegistry;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import io.keen.client.java.KeenCallback;
+import io.keen.client.java.KeenProject;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class TreasureDataInstrumentTest extends TestCase {
+    private static final String DUMMY_API_KEY = "dummy_api_key";
+
+    class Event {
+        String tag;
+        Map<String, Object> event;
+        Event(String tag, Map<String, Object>event) {
+            this.tag = tag;
+            this.event = event;
+        }
+    }
+
+    class MockTDClient extends TDClient {
+        Exception exceptionOnQueueEventCalled;
+        Exception exceptionOnSendQueuedEventsCalled;
+        String errorCodeOnQueueEventCalled;
+        String errorCodeOnSendQueuedEventsCalled;
+        List<Event> addedEvent = new ArrayList<Event>();
+
+        MockTDClient(String apiKey) throws IOException {
+            super(apiKey);
+        }
+
+        public void clearAddedEvent() {
+            addedEvent = new ArrayList<Event>();
+        }
+
+        @Override
+        public void queueEvent(KeenProject project, String eventCollection, Map<String, Object> event, Map<String, Object> keenProperties, KeenCallback callback) {
+            if (exceptionOnQueueEventCalled == null) {
+                addedEvent.add(new Event(eventCollection, event));
+                callback.onSuccess();
+            }
+            else {
+                if (callback instanceof KeenCallbackWithErrorCode) {
+                    KeenCallbackWithErrorCode callbackWithErrorCode = (KeenCallbackWithErrorCode) callback;
+                    callbackWithErrorCode.setErrorCode(errorCodeOnQueueEventCalled);
+                    callbackWithErrorCode.onFailure(exceptionOnQueueEventCalled);
+                }
+                else {
+                    callback.onFailure(exceptionOnQueueEventCalled);
+                }
+            }
+        }
+
+        @Override
+        public void sendQueuedEventsAsync(KeenProject project, KeenCallback callback) {
+            if (exceptionOnSendQueuedEventsCalled == null) {
+                callback.onSuccess();
+            }
+            else {
+                if (callback instanceof KeenCallbackWithErrorCode) {
+                    ((KeenCallbackWithErrorCode) callback).setErrorCode(errorCodeOnSendQueuedEventsCalled);
+                }
+                callback.onFailure(exceptionOnSendQueuedEventsCalled);
+            }
+        }
+    }
+
+    private Context context;
+    private MockTDClient client;
+    private TreasureData td;
+
+    private TreasureData createTreasureData(Context context, TDClient client) {
+        return new TreasureData(context, client, null);
+    }
+
+    public void setUp() throws IOException {
+        Application application = mock(Application.class);
+        context = InstrumentationRegistry.getTargetContext();
+
+        client = new MockTDClient(DUMMY_API_KEY);
+        td = spy(createTreasureData(context, client));
+    }
+
+    public void testEnableAutoAppendAdvertisingId() throws IOException {
+        td.enableAutoAppendAdvertisingIdentifier();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            fail();
+        }
+
+        Map<String, Object> records = new HashMap<String, Object>();
+        records.put("key", "val");
+        td.addEvent("db_", "tbl", records);
+        td.uploadEvents();
+        assertEquals(1, client.addedEvent.size());
+        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
+        assertEquals(2, client.addedEvent.get(0).event.size());
+        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
+        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
+        assertTrue(client.addedEvent.get(0).event.containsKey("td_maid"));
+    }
+
+    public void testDisableAutoAppendAdvertisingId() throws IOException {
+        td.enableAutoAppendAdvertisingIdentifier();
+        td.disableAutoAppendAdvertisingIdentifier();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            fail();
+        }
+
+        Map<String, Object>records = new HashMap<String, Object>();
+        records.put("key", "val");
+        td.addEvent("db_", "tbl", records);
+        td.uploadEvents();
+        assertEquals(1, client.addedEvent.size());
+        assertEquals("db_.tbl", client.addedEvent.get(0).tag);
+        assertEquals(1, client.addedEvent.get(0).event.size());
+        assertTrue(client.addedEvent.get(0).event.containsKey("key"));
+        assertTrue(client.addedEvent.get(0).event.containsValue("val"));
+    }
+}

--- a/test-host/src/main/AndroidManifest.xml
+++ b/test-host/src/main/AndroidManifest.xml
@@ -8,5 +8,9 @@
         android:icon="@mipmap/ic_launcher"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"/>
+        android:theme="@style/AppTheme">
+        <meta-data
+            android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+            android:value="true" />
+    </application>
 </manifest>


### PR DESCRIPTION
### Implementation
- API to enable and disable feature.
- API to enable feature with customized column name.
- Use reflection to avoid using google play service ads library.
- Log out error if client enable feature but have not using google play service ads library yet.
- Passthrough null string when users turn on Limit ad tracking.
- Add advertising identifier to every records if feature is enabled and there is google play service ads library.

### Test
- Test GetAdvertisingIdAsyncTask can get advertising id
- Test enable feature must have ad id in tracked event
- Test disable feature must not have ad id in tracked event