### PR TITLE
Add test coverage for Android API level 29

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,28 @@
 # Very minimal setup, just for the sake of automated testing
-# TODO: Should cache the Gradle dependencies
-# TODO: Export tasks report
 
 version: 2
+
+_defaults:
+  - &restore_gradle_cache:
+    restore_cache:
+      name: Restore Gradle Cache
+      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+  - &download_dependencies:
+    run:
+      name: Download Dependencies
+      command: ./gradlew androidDependencies
+  - &save_gradle_cache:
+    save_cache:
+      paths:
+        - ~/.gradle
+      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+  - &run_tests:
+    run:
+      name: Run Tests
+      command: ./gradlew test
+  - &store_tests_report:
+    store_artifacts:
+      - path: ./build/reports/tests/test
 
 jobs:
   test_api_level_29:
@@ -10,13 +30,22 @@ jobs:
       - image: circleci/android:api-29
     steps:
       - checkout
-      - run: ./gradlew test
+      - *restore_gradle_cache
+      - *download_dependencies
+      - *save_gradle_cache
+      - *run_tests
+      - *store_tests_report
+
   test_api_level_28:
     docker:
       - image: circleci/android:api-28
     steps:
       - checkout
-      - run: ./gradlew test
+      - *restore_gradle_cache
+      - *download_dependencies
+      - *save_gradle_cache
+      - *run_tests
+      - *store_tests_report
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ _defaults:
     store_artifacts:
       path: report.tar
       destination: report.tar
-  - &store_test_results:
+  - &store_test_results
       path: build/test-results
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ _defaults:
       path: report.tar
       destination: report.tar
   - &store_test_results
+    store_test_results:
       path: build/test-results
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ _defaults:
       command: ./gradlew test
   - &store_tests_report
     store_artifacts:
-      - path: ./build/reports/tests/test
+      path: ./build/reports/tests/test
 
 jobs:
   test_api_level_29:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ _defaults:
   - &restore_gradle_cache
     restore_cache:
       name: Restore Gradle Cache
-      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      key: jars-{{ checksum "build.gradle" }}
   - &download_dependencies
     run:
       name: Download Dependencies
@@ -15,19 +15,21 @@ _defaults:
     save_cache:
       paths:
         - ~/.gradle
-      key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
+      key: jars-{{ checksum "build.gradle" }}
   - &run_tests
     run:
       name: Run Tests
       command: ./gradlew test
-  - &compress_tests_report
+  - &compress_report
     run:
-      name: Compress Tests Report
-      command: tar -cvf tests_report.tar ./build/reports/tests/test
-  - &store_tests_report
+      name: Compress Report
+      command: tar -cvf report.tar -C ./build/reports .
+  - &store_report
     store_artifacts:
-      path: tests_report.tar
-      destination: tests_report.tar
+      path: report.tar
+      destination: report.tar
+  - &store_test_results:
+      path: build/test-results
 
 jobs:
   test_api_level_29:
@@ -39,8 +41,9 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - *compress_tests_report
-      - *store_tests_report
+      - *compress_report
+      - *store_report
+      - *store_test_results
 
   test_api_level_28:
     docker:
@@ -51,8 +54,9 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - *compress_tests_report
-      - *store_tests_report
+      - *compress_report
+      - *store_report
+      - *store_test_results
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,24 +3,24 @@
 version: 2
 
 _defaults:
-  - &restore_gradle_cache:
+  - &restore_gradle_cache
     restore_cache:
       name: Restore Gradle Cache
       key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-  - &download_dependencies:
+  - &download_dependencies
     run:
       name: Download Dependencies
       command: ./gradlew androidDependencies
-  - &save_gradle_cache:
+  - &save_gradle_cache
     save_cache:
       paths:
         - ~/.gradle
       key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
-  - &run_tests:
+  - &run_tests
     run:
       name: Run Tests
       command: ./gradlew test
-  - &store_tests_report:
+  - &store_tests_report
     store_artifacts:
       - path: ./build/reports/tests/test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,26 @@
 # Very minimal setup, just for the sake of automated testing
+# TODO: Should cache the Gradle dependencies
+# TODO: Export tasks report
 
 version: 2
 
 jobs:
-  build:
-
+  test_api_level_29:
     docker:
-      - image: circleci/android:api-28
-
+      - image: circleci/android:api-29
     steps:
       - checkout
-
-      # TODO: Should cache the Gradle dependencies
-      # TODO: Export tasks report
-
       - run: ./gradlew test
+  test_api_level_28:
+    docker:
+      - image: circleci/android:api-28
+    steps:
+      - checkout
+      - run: ./gradlew test
+
+workflows:
+  version: 2
+  test:
+    jobs:
+      - test_api_level_29
+      - test_api_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,9 +20,14 @@ _defaults:
     run:
       name: Run Tests
       command: ./gradlew test
+  - &compress_tests_report
+    run:
+      name: Compress Tests Report
+      command: tar -cvf tests_report.tar ./build/reports/tests/test
   - &store_tests_report
     store_artifacts:
-      path: ./build/reports/tests/test
+      path: tests_report.tar
+      destination: tests_report.tar
 
 jobs:
   test_api_level_29:
@@ -34,6 +39,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *compress_tests_report
       - *store_tests_report
 
   test_api_level_28:
@@ -45,6 +51,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *compress_tests_report
       - *store_tests_report
 
 workflows:

--- a/src/test/java/com/treasuredata/android/TDClientTest.java
+++ b/src/test/java/com/treasuredata/android/TDClientTest.java
@@ -6,12 +6,10 @@ import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.RecordedRequest;
 
-import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.Ignore;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;


### PR DESCRIPTION
- Add test coverage for Android API level 29
- Add Save and Restore Gradle Cache step to Circle CI
- Add test result step to Circle CI
- Add save report as artifact to Circle CI
- Fix `sendToTwoTablesWithLimitedUploadedEvents` test case failure