### PR TITLE
Update link to Profiles API

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,9 +473,9 @@ If you want to use server side upload timestamp not only client device time that
 	td.enableServerSideUploadTimestamp("server_upload_time");
 ```
 
-### Profile API
+### Profiles API
 
-Lookup for profiles via [Profile API](https://support.treasuredata.com/hc/en-us/sections/360000271688-Profiles-API)
+Lookup for profiles via [Profiles API](https://docs.treasuredata.com/display/public/PD/Working+with+Profiles+and+the+Profiles+API+Tokens)
 
 ```
 // Set your CDP endpoint to either:


### PR DESCRIPTION
Clicking on the old link shows the following:
```
oops
Our Product Documentation have been moved to https://go.treasuredata.com/docs

The page you were looking for doesn't exist
You may have mistyped the address or the page may have moved

Take me back to the home page
```
Hence, updating the correct link.