### PR TITLE
[CLT-1757] Auto deploy docs microsite on changes to master

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -1,0 +1,54 @@
+name: Deploy Docs Microsite
+
+on:
+  workflow_dispatch:
+    inputs:
+      tags:
+        description: 'Who triggered this test run?'
+        default: ${{github.actor}}
+  push:
+    branches:
+      - master
+    paths:
+      - 'src/**'
+
+jobs:
+  deploy-docs-microsite:
+    name: Build and Deploy Docs microsite to treasure-data.github.io/td-android-sdk
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up the Java JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: git checkout master
+        uses: actions/checkout@v2
+        with:
+          ref: 'master'
+          path: td-android-sdk
+      - name: pull docs branch
+        uses: actions/checkout@v2
+        with:
+          persistent-creadentials: false
+          fetch-depth: 0
+          ref: 'gh-pages'
+          path: gh-pages
+      - name: build docs
+        run: |
+          ls
+          pwd
+          cd ~/td-android-sdk
+          javadoc -d ~/gh-pages ./src/main/java/com/treasuredata/android/*.java
+          cd ~/gh-pages
+          rm -rf ~/td-android-sdk
+      - name: clean docs
+        id: tidy
+        uses: cicirello/javadoc-cleanup@v1
+        with:
+          path-to-root: gh-pages
+      - name: deploy docs
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -25,28 +25,20 @@ jobs:
       - name: git checkout master
         uses: actions/checkout@v2
         with:
-          ref: 'master'
-          path: td-android-sdk
-      - name: pull docs branch
-        uses: actions/checkout@v2
-        with:
           persistent-creadentials: false
           fetch-depth: 0
-          ref: 'gh-pages'
-          path: gh-pages
+          ref: 'master'
+          # path: td-android-sdk
       - name: build docs
         run: |
           ls
           pwd
-          cd ~/td-android-sdk
-          javadoc -d ~/gh-pages ./src/main/java/com/treasuredata/android/*.java
-          cd ~/gh-pages
-          rm -rf ~/td-android-sdk
+          javadoc -d docs ./src/main/java/com/treasuredata/android/*.java
       - name: clean docs
         id: tidy
         uses: cicirello/javadoc-cleanup@v1
         with:
-          path-to-root: gh-pages
+          path-to-root: docs
       - name: deploy docs
         uses: ad-m/github-push-action@master
         with:

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -5,42 +5,87 @@ on:
     inputs:
       tags:
         description: 'Who triggered this test run?'
-        default: ${{github.actor}}
   push:
     branches:
       - master
     paths:
-      - 'src/**'
+      - 'src/main/**'
 
 jobs:
   deploy-docs-microsite:
     name: Build and Deploy Docs microsite to treasure-data.github.io/td-android-sdk
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
-      - name: Set up the Java JDK
-        uses: actions/setup-java@v2
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-      - name: git checkout master
+      - name: Setup
+        continue-on-error: true
+        run: |
+          sudo apt update
+          sudo apt-get -y install default-jdk
+          sudo apt-get -y install android-sdk
+          sudo apt-get -y install gradle
+          export ANDROID_SDK_ROOT='/usr/lib/android-sdk'
+          sudo apt-get -y install unzip
+          wget https://dl.google.com/android/repository/commandlinetools-linux-6609375_latest.zip
+          sudo unzip -o commandlinetools-linux-6609375_latest.zip -d $ANDROID_SDK_ROOT/cmdline-tools
+          export PATH=$ANDROID_SDK_ROOT/cmdline-tools/tools/bin:$PATH
+          yes | sudo /usr/lib/android-sdk/cmdline-tools/tools/bin/sdkmanager --licenses
+          echo "[log] "
+          pwd
+          echo "Current Folder:"
+          ls
+          echo "cmdline tools"
+          ls /usr/lib/android-sdk/
+
+      - name: git checkout
         uses: actions/checkout@v2
         with:
           persistent-creadentials: false
           fetch-depth: 0
+          repository: 'blackstoneengineering/td-android-sdk'
           ref: 'master'
-          # path: td-android-sdk
+          path: td-android-sdk
+      # - name: git checkout - debug
+      #   run: |
+      #     git clone https://github.com/blackstoneengineering/td-android-sdk td-android-sdk
+      #     cd td-android-sdk
+      #     git checkout master
       - name: build docs
+        continue-on-error: true
         run: |
-          ls
-          pwd
-          javadoc -d docs ./src/main/java/com/treasuredata/android/*.java
+          export ANDROID_SDK_ROOT='/usr/lib/android-sdk'
+          cd $GITHUB_WORKSPACE/td-android-sdk
+          sudo ./gradlew javadocJar
       - name: clean docs
         id: tidy
         uses: cicirello/javadoc-cleanup@v1
         with:
-          path-to-root: docs
+          path-to-root: td-android-sdk/build/docs/javadoc
+      - name: Commit Docs
+        run: |
+          sudo mkdir $GITHUB_WORKSPACE/docs
+          sudo mv -f td-android-sdk/build/docs/javadoc $GITHUB_WORKSPACE/docs
+          cd $GITHUB_WORKSPACE/td-android-sdk
+          git config user.email "ci-bot@treasure-data.com"
+          git config user.name "ci-bot"
+          git stash
+          git reset --hard
+          git fetch
+          git checkout gh-pages
+          git pull
+          sudo rm -rf ./docs
+          sudo mv $GITHUB_WORKSPACE/docs ./docs
+          echo "[log git status]"
+          git status
+          git add ./docs/*
+          git commit -m "[ci-bot] Updating docs microsite to latest from master"
+          echo "[log pwd]"
+          pwd
+          echo "[log env]"
+          env
       - name: deploy docs
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: gh-pages
+          directory: td-android-sdk


### PR DESCRIPTION
This will add a github action to track the master branch, and on changes to the src/main/**.java it will rebuild and push the microsite to treasure-data.github.io/td-android-sdk . 

Depends on : https://github.com/treasure-data/td-android-sdk/pull/68 - please merge this first. 