### PR TITLE
Circle CI tests for api level 31

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -108,7 +108,7 @@ jobs:
       - run_instrument_tests:
           api_level: '29'
 
-    instrument_tests_level_28:
+  instrument_tests_level_28:
     executor:
       name: android/android-machine
       resource-class: large

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,38 +40,36 @@ _defaults:
       path: build/test-results
 
 jobs:
-  test_api_level_31:
-    # docker:
-      # - image: cimg/android:2021.10.2
+  instrument_tests_level_29:
     executor:
       name: android/android-machine
       resource-class: medium
+    steps:
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-29;default;x86
+    
+  test_api_level_31:
+    docker:
+      - image: cimg/android:2021.10.2
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-31;default;x86
       - *compress_report
       - *store_report
       - *store_test_results
 
   test_api_level_30:
-    # docker:
-    #   - image: circleci/android:api-30
-    executor:
-      name: android/android-machine
-      resource-class: medium
+    docker:
+      - image: circleci/android:api-30
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-30;default;x86
       - *compress_report
       - *store_report
       - *store_test_results
@@ -108,7 +106,8 @@ workflows:
   version: 2
   test:
     jobs:
-      - test_api_level_31
-      - test_api_level_30
+      - instrument_tests_level_29
+      # - test_api_level_31
+      # - test_api_level_30
       # - test_api_level_29
       # - test_api_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,6 +90,7 @@ jobs:
       - checkout
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;google_apis;x86_64
+          wait-for-emulator: false
           # pre-emulator-wait-steps:
             # - run:
                 # command: adb shell input keyevent 82
@@ -124,8 +125,8 @@ workflows:
   version: 2
   test:
     jobs:
-      - local_tests
+      # - local_tests
       - instrument_tests_level_31
       # - instrument_tests_level_30
       # - instrument_tests_level_29
-      - instrument_tests_level_28
+      # - instrument_tests_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,6 +64,14 @@ commands:
 
 
 jobs:
+  instrument_tests_level_31:
+    executor:
+      name: android/android-machine
+      resource-class: large
+    steps:
+      - run_instrument_tests:
+          api_level: '31'
+
   instrument_tests_level_30:
     executor:
       name: android/android-machine
@@ -138,6 +146,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - instrument_tests_level_31
       - instrument_tests_level_30
       - instrument_tests_level_29
       # - test_api_level_31

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-29;default;x86
+          system-image: system-images;android-29;google_apis;x86
     
   test_api_level_31:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,9 +90,9 @@ jobs:
       - checkout
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;google_apis;x86_64
-          pre-emulator-wait-steps:
-            - run:
-                command: adb shell input keyevent 82
+          # pre-emulator-wait-steps:
+            # - run:
+                # command: adb shell input keyevent 82
       - store_instrument_results
 
   instrument_tests_level_30:
@@ -126,6 +126,6 @@ workflows:
     jobs:
       - local_tests
       - instrument_tests_level_31
-      - instrument_tests_level_30
-      - instrument_tests_level_29
+      # - instrument_tests_level_30
+      # - instrument_tests_level_29
       - instrument_tests_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
       - checkout
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-29;google_apis;x86
+      - store_artifacts:
+          path: /home/circleci/project/test-host/build/reports/androidTests/connected
     
   test_api_level_31:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ jobs:
   instrument_tests_level_29:
     executor:
       name: android/android-machine
-      resource-class: medium
+      resource-class: large
     steps:
       - checkout
       - android/start-emulator-and-run-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,9 @@
 
 version: 2
 
+orbs:
+  android: circleci/android@1.0
+
 _defaults:
   - &restore_gradle_cache
     restore_cache:
@@ -20,6 +23,10 @@ _defaults:
     run:
       name: Run Tests
       command: ./gradlew test
+  - &run_connected_android_tests
+      run:
+        name:  Run Connected Android Tests
+        command: ./gradlew connectedAndroidTest
   - &compress_report
     run:
       name: Compress Report
@@ -33,6 +40,19 @@ _defaults:
       path: build/test-results
 
 jobs:
+  test_api_level_31:
+    docker:
+      - image: cimg/android:2021.10.2
+    steps:
+      - checkout
+      - *restore_gradle_cache
+      - *download_dependencies
+      - *save_gradle_cache
+      - *run_tests
+      - *compress_report
+      - *store_report
+      - *store_test_results
+
   test_api_level_30:
     docker:
       - image: circleci/android:api-30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ jobs:
       - checkout
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;google_apis;x86_64
-          post-emulator-wait-steps:
+          pre-emulator-wait-steps:
             - run:
                 command: adb shell input keyevent 82
       - store_instrument_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,18 +39,47 @@ _defaults:
     store_test_results:
       path: build/test-results
 
+
+commands:
+  store_instrument_results:
+    description: "Store instrument test results"
+    steps:
+      - run:
+          name: Compress Report
+          command: tar -cvf instrument-report.tar -C ./test-host/build/reports/androidTests/connected .
+      - store_artifacts:
+          path: instrument-report.tar
+          destination: instrument-report.tar
+
+  run_instrument_tests:
+    description: "Run instrument tests"
+    parameters:
+      api_level:
+        type: "string"
+    steps:
+      - checkout
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-<<parameters.api_level>>;google_apis;x86
+      - store_instrument_results
+
+
 jobs:
+  instrument_tests_level_30:
+    executor:
+      name: android/android-machine
+      resource-class: large
+    steps:
+      - run_instrument_tests:
+          api_level: '30'
+
   instrument_tests_level_29:
     executor:
       name: android/android-machine
       resource-class: large
     steps:
-      - checkout
-      - android/start-emulator-and-run-tests:
-          system-image: system-images;android-29;google_apis;x86
-      - store_artifacts:
-          path: /home/circleci/project/test-host/build/reports/androidTests/connected
-    
+      - run_instrument_tests:
+          api_level: '29'
+
   test_api_level_31:
     docker:
       - image: cimg/android:2021.10.2
@@ -109,6 +138,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - instrument_tests_level_30
       - instrument_tests_level_29
       # - test_api_level_31
       # - test_api_level_30

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,7 @@ jobs:
       name: android/android-machine
       resource-class: medium
     steps:
+      - checkout
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-29;default;x86
     

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-s;google_apis;x86
+          system-image: system-images;android-s;google_apis;x86_64
       - store_instrument_results
 
   instrument_tests_level_30:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,13 +43,16 @@ jobs:
   test_api_level_31:
     # docker:
       # - image: cimg/android:2021.10.2
+    executor:
+      name: android/android-machine
+      resource-class: medium
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - android/run-ui-tests:
+      - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;default;x86
       - *compress_report
       - *store_report
@@ -58,13 +61,16 @@ jobs:
   test_api_level_30:
     # docker:
     #   - image: circleci/android:api-30
+    executor:
+      name: android/android-machine
+      resource-class: medium
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - android/run-ui-tests:
+      - android/start-emulator-and-run-tests:
           system-image: system-images;android-30;default;x86
       - *compress_report
       - *store_report
@@ -103,6 +109,6 @@ workflows:
   test:
     jobs:
       - test_api_level_31
-      # - test_api_level_30
+      - test_api_level_30
       # - test_api_level_29
       # - test_api_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,7 @@ jobs:
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-31;google_apis;x86_64
+          system-image: system-images;android-s;google_apis;x86
       - store_instrument_results
 
   instrument_tests_level_30:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,8 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;google_apis;x86_64
           post-emulator-wait-steps:
-            - adb shell input keyevent 82
+            - run:
+                command: adb shell input keyevent 82
       - store_instrument_results
 
   instrument_tests_level_30:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,9 +91,6 @@ jobs:
       - android/start-emulator-and-run-tests:
           system-image: system-images;android-31;google_apis;x86_64
           wait-for-emulator: false
-          # pre-emulator-wait-steps:
-            # - run:
-                # command: adb shell input keyevent 82
       - store_instrument_results
 
   instrument_tests_level_30:
@@ -125,8 +122,8 @@ workflows:
   version: 2
   test:
     jobs:
-      # - local_tests
+      - local_tests
       - instrument_tests_level_31
-      # - instrument_tests_level_30
-      # - instrument_tests_level_29
-      # - instrument_tests_level_28
+      - instrument_tests_level_30
+      - instrument_tests_level_29
+      - instrument_tests_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,7 +89,9 @@ jobs:
     steps:
       - checkout
       - android/start-emulator-and-run-tests:
-          system-image: system-images;android-s;google_apis;x86_64
+          system-image: system-images;android-31;google_apis;x86_64
+          post-emulator-wait-steps:
+            - adb shell input keyevent 82
       - store_instrument_results
 
   instrument_tests_level_30:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,15 +62,35 @@ commands:
           system-image: system-images;android-<<parameters.api_level>>;google_apis;x86
       - store_instrument_results
 
+  run_local_tests:
+    description: "Run unit tests"
+    steps:
+      - checkout
+      - *restore_gradle_cache
+      - *download_dependencies
+      - *save_gradle_cache
+      - *run_tests
+      - *compress_report
+      - *store_report
+      - *store_test_results
+
 
 jobs:
+  local_tests:
+    docker:
+      - image: circleci/android:api-30
+    steps:
+      - run_local_tests
+
   instrument_tests_level_31:
     executor:
       name: android/android-machine
       resource-class: large
     steps:
-      - run_instrument_tests:
-          api_level: '31'
+      - checkout
+      - android/start-emulator-and-run-tests:
+          system-image: system-images;android-31;google_apis;x86_64
+      - store_instrument_results
 
   instrument_tests_level_30:
     executor:
@@ -88,68 +108,21 @@ jobs:
       - run_instrument_tests:
           api_level: '29'
 
-  test_api_level_31:
-    docker:
-      - image: cimg/android:2021.10.2
+    instrument_tests_level_28:
+    executor:
+      name: android/android-machine
+      resource-class: large
     steps:
-      - checkout
-      - *restore_gradle_cache
-      - *download_dependencies
-      - *save_gradle_cache
-      - *run_tests
-      - *compress_report
-      - *store_report
-      - *store_test_results
+      - run_instrument_tests:
+          api_level: '28'
 
-  test_api_level_30:
-    docker:
-      - image: circleci/android:api-30
-    steps:
-      - checkout
-      - *restore_gradle_cache
-      - *download_dependencies
-      - *save_gradle_cache
-      - *run_tests
-      - *compress_report
-      - *store_report
-      - *store_test_results
-
-  test_api_level_29:
-    docker:
-      - image: circleci/android:api-29
-    steps:
-      - checkout
-      - *restore_gradle_cache
-      - *download_dependencies
-      - *save_gradle_cache
-      - *run_tests
-      - *run_connected_android_tests
-      - *compress_report
-      - *store_report
-      - *store_test_results
-
-  test_api_level_28:
-    docker:
-      - image: circleci/android:api-28
-    steps:
-      - checkout
-      - *restore_gradle_cache
-      - *download_dependencies
-      - *save_gradle_cache
-      - *run_tests
-      - *run_connected_android_tests
-      - *compress_report
-      - *store_report
-      - *store_test_results
 
 workflows:
   version: 2
   test:
     jobs:
+      - local_tests
       - instrument_tests_level_31
       - instrument_tests_level_30
       - instrument_tests_level_29
-      # - test_api_level_31
-      # - test_api_level_30
-      # - test_api_level_29
-      # - test_api_level_28
+      - instrument_tests_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ workflows:
   version: 2
   test:
     jobs:
-      - test_api_level_30
-      - test_api_level_29
-      - test_api_level_28
+      - test_api_level_31
+      # - test_api_level_30
+      # - test_api_level_29
+      # - test_api_level_28

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 # Very minimal setup, just for the sake of automated testing
 
-version: 2
+version: 2.1
 
 orbs:
-  android: circleci/android@1.0
+  android: circleci/android@1.0.3
 
 _defaults:
   - &restore_gradle_cache
@@ -41,29 +41,31 @@ _defaults:
 
 jobs:
   test_api_level_31:
-    docker:
-      - image: cimg/android:2021.10.2
+    # docker:
+      # - image: cimg/android:2021.10.2
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - *run_connected_android_tests
+      - android/run-ui-tests:
+          system-image: system-images;android-31;default;x86
       - *compress_report
       - *store_report
       - *store_test_results
 
   test_api_level_30:
-    docker:
-      - image: circleci/android:api-30
+    # docker:
+    #   - image: circleci/android:api-30
     steps:
       - checkout
       - *restore_gradle_cache
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
-      - *run_connected_android_tests
+      - android/run-ui-tests:
+          system-image: system-images;android-30;default;x86
       - *compress_report
       - *store_report
       - *store_test_results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *run_connected_android_tests
       - *compress_report
       - *store_report
       - *store_test_results
@@ -62,6 +63,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *run_connected_android_tests
       - *compress_report
       - *store_report
       - *store_test_results
@@ -75,6 +77,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *run_connected_android_tests
       - *compress_report
       - *store_report
       - *store_test_results
@@ -88,6 +91,7 @@ jobs:
       - *download_dependencies
       - *save_gradle_cache
       - *run_tests
+      - *run_connected_android_tests
       - *compress_report
       - *store_report
       - *store_test_results


### PR DESCRIPTION
### Purpose
Need to run test for Android 12 (API level 31)

### Overview
- Update structure of config
- Add instrument tests
- Add instrument tests for API level 31. In this PR, we need a small workaround of turning of wait-for-emulator step because that step hangs forever. The step should be turned back on in the future if the issue is resolved

### Impact
None

### Rollback
Revert