### PR TITLE
Release version 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log
 
+## version 1.0.0
+_2023-02-27_
+
+* Add support for Ingest API and Ingest format
+* Event collector and keen format are no longer supported
+* New intialization APIs with removed initWithEndpoint() API
+
 ## Version 0.6.0
 _2021_04_22_
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ If you use gradle, add the following dependency to `dependencies` directive in t
 
 ```
 dependencies {
-    implementation 'com.treasuredata:td-android-sdk:0.6.0'
+    implementation 'com.treasuredata:td-android-sdk:1.0.0'
 }
 ```
 
@@ -34,7 +34,7 @@ If you use maven, add the following directives to your pom.xml
   <dependency>
     <groupId>com.treasuredata</groupId>
     <artifactId>td-android-sdk</artifactId>
-    <version>0.6.0</version>
+    <version>1.0.0</version>
   </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'com.treasuredata'
-version = '0.6.0'
+version = '1.0.0'
 description = 'Android SDK for Treasure Data Cloud'
 sourceCompatibility = '1.7'
 

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -35,7 +35,7 @@ import static android.content.Context.UI_MODE_SERVICE;
 
 public class TreasureData implements CDPClient {
     private static final String TAG = TreasureData.class.getSimpleName();
-    private static final String VERSION = "0.6.0";
+    private static final String VERSION = "1.0.0";
     private static final String LABEL_ADD_EVENT = "addEvent";
     private static final String LABEL_UPLOAD_EVENTS = "uploadEvents";
     private static final Pattern DATABASE_NAME_PATTERN = Pattern.compile("^[0-9a-z_]{3,255}$");


### PR DESCRIPTION
## version 1.0.0
_2023-02-27_

* Add support for Ingest API and Ingest format
* Event collector and keen format are no longer supported
* New intialization APIs with removed initWithEndpoint: API