### PR TITLE
Auto tracking IP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 dependencies {
     implementation 'org.komamitsu:android-logger-bridge:0.0.2'
     implementation 'com.fasterxml.jackson.jr:jackson-jr-objects:2.17.0'
-    implementation 'com.treasuredata:keen-client-java-core:3.0.0'
+    implementation 'com.treasuredata:keen-client-java-core:3.0.1'
 
     compileOnly 'com.google.android:android:4.1.1.4'
 

--- a/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
+++ b/example/src/main/java/com/treasuredata/android/demo/DemoApp.java
@@ -9,6 +9,7 @@ import com.android.installreferrer.api.ReferrerDetails;
 import com.treasuredata.android.TreasureData;
 
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by vinhvd on 2/6/18.

--- a/src/main/java/com/treasuredata/android/TDClient.java
+++ b/src/main/java/com/treasuredata/android/TDClient.java
@@ -27,6 +27,7 @@ class TDClient extends KeenClient {
                         .withJsonHandler(new TDJsonHandler(encryptionKey))
                         .withPublishExecutor(Executors.newSingleThreadExecutor())
         );
+
         // setDebugMode(true);
         setApiKey(apiKey);
         setActive(true);
@@ -56,7 +57,10 @@ class TDClient extends KeenClient {
     // Only for test
     @Deprecated
     TDClient(String apiKey) {
-        super(new TDClientBuilder());
+        super(
+                new TDClientBuilder()
+                        .withHttpHandler(new TDHttpHandler(apiKey, "test-endpoint"))
+        );
         setApiKey(apiKey);
     }
 

--- a/src/main/java/com/treasuredata/android/TDHttpHandler.java
+++ b/src/main/java/com/treasuredata/android/TDHttpHandler.java
@@ -16,6 +16,8 @@ class TDHttpHandler extends UrlConnectionHttpHandler {
     private final String apiKey;
     private final String apiEndpoint;
 
+    volatile boolean isTrackingIPEnabled = false;
+
     public static void disableEventCompression() {
         isEventCompression = false;
     }
@@ -36,10 +38,11 @@ class TDHttpHandler extends UrlConnectionHttpHandler {
     }
 
     protected void sendRequest(HttpURLConnection connection, Request request) throws IOException {
+        String contentType = isTrackingIPEnabled ? "application/vnd.treasuredata.v1.mobile+json" : "application/vnd.treasuredata.v1+json";
         connection.setRequestMethod("POST");
         connection.setRequestProperty("Authorization", "TD1 " + apiKey);
-        connection.setRequestProperty("Content-Type", "application/vnd.treasuredata.v1+json");
-        connection.setRequestProperty("Accept", "application/vnd.treasuredata.v1+json");
+        connection.setRequestProperty("Content-Type", contentType);
+        connection.setRequestProperty("Accept", contentType);
         connection.setRequestProperty("User-Agent", String.format("TD-Android-SDK/%s (%s %s)", VERSION, Build.MODEL, Build.VERSION.RELEASE));
         connection.setDoOutput(true);
 

--- a/src/main/java/com/treasuredata/android/TreasureData.java
+++ b/src/main/java/com/treasuredata/android/TreasureData.java
@@ -497,6 +497,23 @@ public class TreasureData implements CDPClient {
     }
 
     /**
+     * Device's IP will be added to td_ip column in Treasure Data backend.
+     */
+    public void enableAutoTrackingIP() {
+        TDHttpHandler tdHttpHandler = (TDHttpHandler) client.getHttpHandler();
+        tdHttpHandler.isTrackingIPEnabled = true;
+    }
+
+    /**
+     * Device's IP will not be added to td_ip column in Treasure Data backend.
+     * This is the default behavior.
+     */
+    public void disableAutoTrackingIP() {
+        TDHttpHandler tdHttpHandler = (TDHttpHandler) client.getHttpHandler();
+        tdHttpHandler.isTrackingIPEnabled = false;
+    }
+
+    /**
      * The destination database for events that doesn't specify one, default is "td".
      *
      * @param defaultDatabase name of the destination database

--- a/src/test/java/com/treasuredata/android/TreasureDataTest.java
+++ b/src/test/java/com/treasuredata/android/TreasureDataTest.java
@@ -6,6 +6,7 @@ import android.content.Context;
 import io.keen.client.java.KeenCallback;
 import io.keen.client.java.KeenClient;
 import io.keen.client.java.KeenProject;
+
 import junit.framework.TestCase;
 
 import java.io.IOException;
@@ -962,5 +963,17 @@ public class TreasureDataTest extends TestCase {
         Map event1 = client.addedEvent.get(0).event;
         assertEquals(event1.get("key"), "Value");
         assertNull(event1.get("key2"));
+    }
+
+    public void testAutoTrackingIP() {
+        TDHttpHandler tdHttpHandler = (TDHttpHandler) client.getHttpHandler();
+
+        assertFalse(tdHttpHandler.isTrackingIPEnabled);
+
+        td.enableAutoTrackingIP();
+        assertTrue(tdHttpHandler.isTrackingIPEnabled);
+
+        td.disableAutoTrackingIP();
+        assertFalse(tdHttpHandler.isTrackingIPEnabled);
     }
 }


### PR DESCRIPTION
New feature:

- enableAutoTrackingIP will tell TD backend to add td_ip column with the device ip
- disableAutoTrackingIP will disable this behavior.

Note: IP is tracked at the request level. Which means the IP address is the one when uploadEvents is called.